### PR TITLE
Fix：404ページの修正

### DIFF
--- a/app/Http/Controllers/TaskController.php
+++ b/app/Http/Controllers/TaskController.php
@@ -29,6 +29,11 @@ class TaskController extends Controller
     public function show($id)
     {
         $item = Task::find($id);
+
+        if (is_null($item)) {
+            abort(404);
+        }
+
         return view('task.show', compact('item'));
     }
 
@@ -50,6 +55,11 @@ class TaskController extends Controller
     public function edit($id)
     {
         $task = Task::find($id);
+
+        if (is_null($task)) {
+            abort(404);
+        }
+
         return view('task.edit', compact('task'));
     }
 
@@ -66,6 +76,11 @@ class TaskController extends Controller
     public function delete($id)
     {
         $task = Task::find($id);
+
+        if (is_null($task)) {
+            abort(404);
+        }
+        
         return view('task.delete', compact('task'));
     }
 

--- a/resources/views/errors/404.blade.php
+++ b/resources/views/errors/404.blade.php
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Page Not Found</title>
+    <link href="https://fonts.googleapis.com/css?family=Nunito" rel="stylesheet" type="text/css">
+    <style>
+    html,
+    body {
+        background-color: #fff;
+        color: #636b6f;
+        font-family: 'Nunito', sans-serif;
+        font-weight: 100;
+        height: 100vh;
+        margin: 0;
+    }
+
+    .full-height {
+        height: 100vh;
+    }
+
+    .flex-center {
+        align-items: center;
+        display: flex;
+        justify-content: center;
+    }
+
+    .position-ref {
+        position: relative;
+    }
+
+    .content {
+        text-align: center;
+    }
+
+    .title {
+        font-size: 36px;
+        padding: 20px;
+    }
+    </style>
+</head>
+
+<body>
+  <div class="">
+    <div class="flex-center position-ref full-height">
+      <div class="content">
+        <div class="title">404</div>
+        <div class="title">
+          Sorry, the page you are looking for could not be found.
+        </div>
+          <p>お探しのページは見つかりませんでした。</p>
+          <div class="flex-center">
+            @if (Route::has('login'))
+              <div class="px-6 py-4 sm:block">
+                @auth
+                  <a href="{{ url('/task') }}" class="text-sm text-gray-700 dark:text-gray-500 underline">ToDo List</a>
+                @else
+                  <a href="{{ route('login') }}" class="text-sm text-gray-700 dark:text-gray-500 underline">Log in</a>
+                  @if (Route::has('register'))
+                    <a href="{{ route('register') }}" class="ml-4 text-sm text-gray-700 dark:text-gray-500 underline">Register</a>
+                  @endif
+                @endauth
+              </div>
+            @endif
+          </div>
+      </div>
+    </div>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## 概要

404ページを独自で作成したページに変更しました。
またタスク詳細・編集・削除において、URLに他ユーザーのタスクidまたは存在しないidを直打ちした場合に404ページへ遷移するよう修正しました。

## 確認方法

1. 他ユーザーのタスクidまたは存在しないidを直打ちした場合、404ページに遷移されること。
2. ログイン中に404ページが表示された場合、タスク一覧ページへ戻るボタンが表示され、一覧ページへ遷移できること。