### PR TITLE
Add：完了したタスク一覧ページを作成

### DIFF
--- a/app/Http/Controllers/TaskController.php
+++ b/app/Http/Controllers/TaskController.php
@@ -26,6 +26,20 @@ class TaskController extends Controller
         return view('task.index', compact('items', 'keyword'));
     }
 
+    public function done(Request $request)
+    {
+        $keyword = $request->input('keyword');
+        $query = Task::query();
+
+        if (!empty($keyword)) {
+            $query->where('title', 'LIKE', "%{$keyword}%");
+        }
+
+        $items = $query->get();
+        return view('task.done', compact('items', 'keyword'));
+    }
+
+
     public function show($id)
     {
         $item = Task::find($id);
@@ -80,7 +94,7 @@ class TaskController extends Controller
         if (is_null($task)) {
             abort(404);
         }
-        
+
         return view('task.delete', compact('task'));
     }
 

--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -9,6 +9,11 @@
                         {{ __('ToDo List') }}
                     </x-nav-link>
                 </div>
+                <div class="hidden space-x-8 sm:-my-px sm:ml-10 sm:flex">
+                    <x-nav-link :href="route('done_task')" :active="request()->routeIs('done_task')">
+                        {{ __('Done') }}
+                    </x-nav-link>
+                </div>
             </div>
 
             <!-- Settings Dropdown -->

--- a/resources/views/task/done.blade.php
+++ b/resources/views/task/done.blade.php
@@ -1,0 +1,49 @@
+<x-app-layout>
+  <x-slot name="header">
+      <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+          {{ __('Done') }}
+      </h2>
+  </x-slot>
+
+  <h3 class="text-4xl font-semibold text-gray-900 dark:text-white flex justify-center py-6">Done</h3>
+
+  <div class="flex justify-center text-xl py-6">
+    <form action="{{ route('done_task') }}" method="GET">
+      <input type="text" name="keyword" value="{{ $keyword }}">
+      <input type="submit" value="検索" class="m-1 bg-yellow-100 hover:bg-yellow-200 text-blue-900 py-2 px-4 border border-blue-900 rounded-full shadow">
+    </form>
+  </div>
+
+  <table class="flex justify-center text-xl">
+    <div class="flex justify-center text-xl py-6">
+      <button class="m-1 bg-yellow-100 hover:bg-yellow-200 text-blue-900 py-2 px-4 border border-blue-900 rounded-full shadow">
+        <a href="{{ route('task_add') }}">新しいタスクを登録する</a>
+      </button>
+    </div>
+    @forelse ($items as $item)
+      @if (old('status', $item->status ? '1' : '0') === "1")
+        <div class="max-w-sm w-full lg:max-w-full lg:flex justify-center text-2xl py-6">
+          <figure class="flex flex-col items-center justify-center p-8 text-center bg-white border-b border-gray-200 rounded-t-lg md:rounded-t-none md:rounded-tl-lg md:border-r dark:bg-gray-800 dark:border-gray-700">
+            <div class="text-sm font-light text-gray-500 dark:text-gray-400 pb-3">{{ $item->created_at }}</div>
+            <h3 class="text-lg font-semibold text-gray-900 dark:text-white">{{ $item->title }}</h3>
+              <p class="text-xl my-4 font-light">{{ $item->memo }}</p>
+            <figcaption class="flex items-center justify-center space-x-3">
+              <div class="space-y-0.5 font-medium dark:text-white text-left">
+                @if (old('status', $item->status ? '1' : '0') === "1")
+                  <label for="status">Status: 完了</label>
+                @else
+                  <label for="status" class="text-red-600">Status: 未着手</label>
+                @endif
+                <a href="{{ route('task_show', ['id'=>$item->id]) }}" class="text-base m-1 bg-yellow-100 hover:bg-yellow-200 text-blue-900 py-2 px-4 border border-blue-900 rounded-full shadow">詳細</a>
+                <a href="{{ route('task_edit', ['id'=>$item->id]) }}" class="text-base m-1 bg-yellow-100 hover:bg-yellow-200 text-blue-900 py-2 px-4 border border-blue-900 rounded-full shadow">編集</a>
+                <a href="{{ route('task_delete', ['id'=>$item->id]) }}" class="text-base m-1 bg-pink-100 hover:bg-pink-200 text-blue-900 py-2 px-4 border border-blue-900 rounded-full shadow">削除</a>
+              </div>
+            </figcaption>
+          </figure>
+        </div>
+      @endif
+    @empty
+      <td class="text-xl">完了しているタスクは見つかりませんでした。</td>
+    @endforelse
+  </table>
+</x-app-layout>

--- a/resources/views/task/show.blade.php
+++ b/resources/views/task/show.blade.php
@@ -6,7 +6,6 @@
   </x-slot>
 
   <table>
-    {{-- <div class="mb-8 border border-gray-200 rounded-lg shadow-sm dark:border-gray-700 md:mb-12 md:grid-cols-2"> --}}
     <div class="max-w-sm w-full lg:max-w-full lg:flex justify-center text-2xl py-6">
       <figure class="flex flex-col items-center justify-center p-8 text-center bg-white border-b border-gray-200 rounded-t-lg md:rounded-t-none md:rounded-tl-lg md:border-r dark:bg-gray-800 dark:border-gray-700">
         <div class="text-sm font-light text-gray-500 dark:text-gray-400 pb-3">{{ $item->created_at }}</div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -39,6 +39,7 @@ Route::middleware('auth')->group(function () {
     Route::post('task/delete',  [TaskController::class, 'remove']);
     Route::get('task/find', [TaskController::class, 'find'])->name('task_find');
     Route::post('task/find', [TaskController::class, 'search']);
+    Route::get('task/done', [TaskController::class, 'done'])->name('done_task');
 });
 
 require __DIR__.'/auth.php';


### PR DESCRIPTION
## 概要

完了したタスク一覧ページを作成しました。

## 確認方法

1. Doneを押すと完了したタスク一覧ページへ遷移できること。
2. 表示されているタスクは自分が作成したタスクかつ完了しているタスクであること。
3. タスクの詳細・編集・削除ページへ遷移し、編集・削除ができること。

## コメント

次回、完了したタスク詳細ページから完了したタスク一覧ページへ遷移するボタンを追加します。
