### PR TITLE
Add：並び替えできるボタンを追加

### DIFF
--- a/app/Http/Controllers/TaskController.php
+++ b/app/Http/Controllers/TaskController.php
@@ -16,26 +16,48 @@ class TaskController extends Controller
     public function index (Request $request)
     {
         $keyword = $request->input('keyword');
+        $sort = $request->get('sort');
         $query = Task::query();
 
         if (!empty($keyword)) {
             $query->where('title', 'LIKE', "%{$keyword}%");
         }
 
-        $items = $query->get();
-        return view('task.index', compact('items', 'keyword'));
+        if (!empty($sort)) {
+            if ($sort === '0') {
+                $items = Task::orderBy('created_at')->get();
+            } elseif ($sort === '1') {
+                $items = Task::orderBy('created_at', 'DESC')->get();
+            } elseif ($sort === '2') {
+                $items = Task::orderBy('status')->get();
+            }
+        } else {
+            $items = $query->get();
+        }
+
+        return view('task.index', compact('items', 'keyword', 'sort'));
     }
 
     public function done(Request $request)
     {
         $keyword = $request->input('keyword');
+        $sort = $request->get('sort');
         $query = Task::query();
 
         if (!empty($keyword)) {
             $query->where('title', 'LIKE', "%{$keyword}%");
         }
 
-        $items = $query->get();
+        if (!empty($sort)) {
+            if ($sort === '0') {
+                $items = Task::orderBy('created_at')->get();
+            } elseif ($sort === '1') {
+                $items = Task::orderBy('created_at', 'DESC')->get();
+            } 
+        } else {
+            $items = $query->get();
+        }
+
         return view('task.done', compact('items', 'keyword'));
     }
 

--- a/app/Http/Controllers/TaskController.php
+++ b/app/Http/Controllers/TaskController.php
@@ -20,7 +20,8 @@ class TaskController extends Controller
         $query = Task::query();
 
         if (!empty($keyword)) {
-            $query->where('title', 'LIKE', "%{$keyword}%");
+            $escape_word = addcslashes($keyword, '\\_%');
+            $query->where('title', 'LIKE', "%{$escape_word}%");
         }
 
         if (!empty($sort)) {
@@ -53,7 +54,7 @@ class TaskController extends Controller
                 $items = Task::orderBy('created_at')->get();
             } elseif ($sort === '1') {
                 $items = Task::orderBy('created_at', 'DESC')->get();
-            } 
+            }
         } else {
             $items = $query->get();
         }

--- a/resources/views/task/done.blade.php
+++ b/resources/views/task/done.blade.php
@@ -5,14 +5,16 @@
       </h2>
   </x-slot>
 
-  {{-- <div class="flex justify-center text-xl pt-6">
-    <form action="{{ route('task_index') }}" method="GET">
-      <div class="flex items-center border-b border-teal-500">
-        <input type="text" name="keyword" value="{{ $keyword }}" class="appearance-none bg-transparent border-none w-full text-gray-700 mr-3 py-1 px-2 leading-tight focus:outline-none">
-        <input type="submit" value="検索" class="flex-shrink-0 bg-teal-500 hover:bg-teal-700 border-teal-500 hover:border-teal-700 text-sm border-4 text-white py-1 px-2 rounded">
-      </div>
+  <div class="flex justify-center text-xl pt-6">
+    <form action="{{route('done_task')}}">
+      <button type="submit" name="sort" value="0" class="flex-shrink-0 bg-teal-500 hover:bg-teal-700 border-teal-500 hover:border-teal-700 text-sm border-4 text-white py-1 px-2 rounded">
+        作成日順
+      </button>
+      <button type="submit" name="sort" value="1" class="flex-shrink-0 bg-teal-500 hover:bg-teal-700 border-teal-500 hover:border-teal-700 text-sm border-4 text-white py-1 px-2 rounded">
+        作成日が新しい順
+      </button>
     </form>
-  </div> --}}
+  </div>
 
   <table class="flex justify-center text-xl">
     <div class="flex justify-center text-xl py-12">

--- a/resources/views/task/done.blade.php
+++ b/resources/views/task/done.blade.php
@@ -6,6 +6,15 @@
   </x-slot>
 
   <div class="flex justify-center text-xl pt-6">
+    <form action="{{ route('done_task') }}" method="GET">
+      <div class="flex items-center border-b border-teal-500">
+        <input type="text" name="keyword" value="{{ $keyword }}" class="appearance-none bg-transparent border-none w-full text-gray-700 mr-3 py-1 px-2 leading-tight focus:outline-none">
+        <input type="submit" value="検索" class="flex-shrink-0 bg-teal-500 hover:bg-teal-700 border-teal-500 hover:border-teal-700 text-sm border-4 text-white py-1 px-2 rounded">
+      </div>
+    </form>
+  </div>
+
+  <div class="flex justify-center text-xl pt-6">
     <form action="{{route('done_task')}}">
       <button type="submit" name="sort" value="0" class="flex-shrink-0 bg-teal-500 hover:bg-teal-700 border-teal-500 hover:border-teal-700 text-sm border-4 text-white py-1 px-2 rounded">
         作成日順

--- a/resources/views/task/index.blade.php
+++ b/resources/views/task/index.blade.php
@@ -14,6 +14,20 @@
     </form>
   </div>
 
+  <div class="flex justify-center text-xl pt-6">
+    <form action="{{route('task_index')}}">
+      <button type="submit" name="sort" value="0" class="flex-shrink-0 bg-teal-500 hover:bg-teal-700 border-teal-500 hover:border-teal-700 text-sm border-4 text-white py-1 px-2 rounded">
+        作成日順
+      </button>
+      <button type="submit" name="sort" value="1" class="flex-shrink-0 bg-teal-500 hover:bg-teal-700 border-teal-500 hover:border-teal-700 text-sm border-4 text-white py-1 px-2 rounded">
+        作成日が新しい順
+      </button>
+      <button type="submit" name="sort" value="2" class="flex-shrink-0 bg-teal-500 hover:bg-teal-700 border-teal-500 hover:border-teal-700 text-sm border-4 text-white py-1 px-2 rounded">
+        ステータス順
+      </button>
+    </form>
+  </div>
+
   <table class="flex justify-center text-xl">
     <div class="flex justify-center text-xl py-12">
       <button class="text-base flex-shrink-0 bg-teal-500 hover:bg-teal-700 border-teal-500 hover:border-teal-700 text-sm border-4 text-white py-1 px-2 rounded">


### PR DESCRIPTION
## 概要

一覧ページでタスクの並び替えができるボタンを追加しました。（デフォルトは作成日順）
また完了したタスクを検索できるよう修正しました。

## 確認方法

1. 完了していないタスク一覧ページにて「作成日順」「作成日が新しいタスク順」「ステータス順」で並び替えが出来ること。
2. 完了したタスク一覧ページにて「作成日順」「作成日が新しいタスク順」で並び替えが出来ること。
3. 完了したタスク一覧ページにて検索が出来ること。

## コメント
今後、タスクに期限を設定できるようにし、「作成日が新しいタスク順」を「期限が迫っているタスク順」に変更します。
