### PR TITLE
Add：タグの管理ページを作成

### DIFF
--- a/app/Http/Controllers/TagController.php
+++ b/app/Http/Controllers/TagController.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use App\Models\Tag;
+
+class TagController extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function index(Request $request)
+    {
+        $keyword = $request->input('keyword');
+        $query = Tag::query();
+
+        if (!empty($keyword)) {
+            $escape_word = addcslashes($keyword, '\\_%');
+            $query->where('name', 'LIKE', "%{$escape_word}%");
+        }
+
+        $items = $query->get();
+        return view('tag.index', compact('items', 'keyword'));
+    }
+
+    /**
+     * Show the form for editing the specified resource.
+     *
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+    public function edit($id)
+    {
+        //
+    }
+
+    /**
+     * Update the specified resource in storage.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+    public function update(Request $request, $id)
+    {
+        $this->validate($request, Tag::$rules);
+        $tag = Tag::find($id);
+        $form = $request->all();
+        unset($form['_token']);
+        $tag->fill($form)->save();
+
+        return redirect('/tag');
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     *
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+    public function destroy($id)
+    {
+        Tag::find($id)->delete();
+        return redirect('/tag');
+    }
+}

--- a/app/Models/Tag.php
+++ b/app/Models/Tag.php
@@ -33,4 +33,9 @@ class Tag extends Model
     {
         return $this->belongsToMany('App\Task')->withTimestamps();
     }
+
+    public function scopeNameEqual($query, $str)
+    {
+        return $query->where('name', $str);
+    }
 }

--- a/database/migrations/2023_02_08_125340_add_unique_constraints_to_tags_table.php
+++ b/database/migrations/2023_02_08_125340_add_unique_constraints_to_tags_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('tags', function (Blueprint $table) {
+            $table->unique(['name', 'user_id']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('tags', function (Blueprint $table) {
+            //
+        });
+    }
+};

--- a/resources/views/tag/index.blade.php
+++ b/resources/views/tag/index.blade.php
@@ -1,0 +1,81 @@
+<x-app-layout>
+  <div class="flex justify-center text-xl py-6">
+    <form action="{{ route('tag.index') }}" method="GET" class="px-64">
+      @csrf
+        <div class="flex items-center border-b border-teal-700">
+          <input type="text" name="keyword" value="{{ $keyword }}" class="appearance-none bg-transparent border-none w-full text-gray-700 mr-3 py-1 px-2 leading-tight focus:outline-none">
+          <input type="submit" value="検索" class="flex-shrink-0 bg-teal-500 hover:bg-teal-700 border-teal-500 hover:border-teal-700 text-white text-sm border-4 py-1 px-2 rounded">
+        </div>
+    </form>
+  </div>
+
+  <table>
+    <div class="flex items-center justify-center">
+      <div class="w-full max-w-2xl p-4 bg-white border border-gray-200 rounded-lg shadow sm:p-8 dark:bg-gray-800 dark:border-gray-700">
+        <div class="flex items-center justify-between mb-4">
+          <h5 class="text-xl font-bold leading-none text-gray-900">Tag List</h5>
+          <a href="{{ route('tag.index') }}" class="text-sm font-medium text-indigo-700 hover:underline">
+            View all
+          </a>
+        </div>
+
+        @if (count($errors) > 0)
+          <div class="flex justify-center pt-6">
+            <div class="px-4 py-3 rounded" role="alert">
+              <strong class="text-sm text-rose-700">
+                <ul>
+                @foreach ($errors->all() as $error)
+                  <li>{{ $error }}</li>
+                @endforeach
+              </ul>
+              </strong>
+            </div>
+          </div>
+        @endif
+
+        <div class="flow-root">
+          <ul role="list" class="divide-y divide-gray-200 dark:divide-gray-700">
+            @if ($items)
+              @forelse ($items as $item)
+                <li class="py-3 sm:py-4">
+                  <div class="flex items-center justify-center space-x-4">
+                    <div class="min-w-0 px-6 items-center">
+                      <div class="flex">
+                        <form action="{{ route('tag.update', $item->id) }}" method="post">
+                          @csrf
+                          @method('put')
+                            <div class="flex items-center pr-3">
+                              <p class="text-sm text-gray-900 pr-3">タグ名</p>
+                              <h3 class="text-2xl font-semibold text-gray-900 dark:text-white">
+                                <div class="flex items-center border-b border-teal-500 pt-3">
+                                  <input type="text" name="name" value="{{ $item->name }}" class="appearance-none bg-transparent border-none w-full text-gray-700 mr-3 py-1 px-2 leading-tight focus:outline-none" placeholder="例：掃除">
+                                </div>
+                              </h3>
+                            </div>
+                            <div class="inline-flex">
+                              <input type="submit" value="更新" class="flex-shrink-0 bg-indigo-900 hover:bg-indigo-700 border-indigo-900 hover:border-indigo-700 text-white text-base border-4 py-1 px-2 rounded">
+                            </div>
+                        </form>
+                        <div class="flex justify-center">
+                          <div class="inline-flex text-base font-medium text-gray-900 dark:text-white">
+                            <form action="{{ route('tag.destroy', $item->id) }}" method="post" onsubmit="return confirm('削除してもよろしいですか？')" class="px-1">
+                              @csrf
+                              @method('delete')
+                                <input type="submit" value="削除" class="text-base flex-shrink-0 bg-transparent hover:bg-rose-600 border-transparent hover:border-rose-600 border-4 text-indigo-900 hover:text-white py-1 px-2 rounded">
+                            </form>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </li>
+              @empty
+                <div class="text-sm text-gray-900 pr-3">タグの登録数：0</div>
+              @endforelse
+            @endif
+          </ul>
+        </div>
+      </div>
+    </div>
+  </table>
+</x-app-layout>

--- a/resources/views/task/add.blade.php
+++ b/resources/views/task/add.blade.php
@@ -11,8 +11,8 @@
         </strong>
       </div>
     </div>
-
   @endif
+
   <form action="/task/add" method="post">
     <table class="flex justify-center text-xl">
       @csrf

--- a/resources/views/task/done.blade.php
+++ b/resources/views/task/done.blade.php
@@ -1,10 +1,11 @@
 <x-app-layout>
   <div class="flex justify-center text-xl pt-6">
     <form action="{{ route('done_task') }}" method="GET" class="px-64">
-      <div class="flex items-center border-b border-teal-700">
-        <input type="text" name="keyword" value="{{ $keyword }}" class="appearance-none bg-transparent border-none w-full text-gray-700 mr-3 py-1 px-2 leading-tight focus:outline-none">
-        <input type="submit" value="検索" class="flex-shrink-0 bg-teal-500 hover:bg-teal-700 border-teal-500 hover:border-teal-700 text-white text-sm border-4 py-1 px-2 rounded">
-      </div>
+      @csrf
+        <div class="flex items-center border-b border-teal-700">
+          <input type="text" name="keyword" value="{{ $keyword }}" class="appearance-none bg-transparent border-none w-full text-gray-700 mr-3 py-1 px-2 leading-tight focus:outline-none">
+          <input type="submit" value="検索" class="flex-shrink-0 bg-teal-500 hover:bg-teal-700 border-teal-500 hover:border-teal-700 text-white text-sm border-4 py-1 px-2 rounded">
+        </div>
       <div class="flex justify-center pt-6">
         @if ($tags)
           <div class="flex flex-wrap items-center">
@@ -27,12 +28,13 @@
 
   <div class="flex justify-center text-xl pt-6">
     <form action="{{route('done_task')}}">
-      <button type="submit" name="sort" value="0" class="flex-shrink-0 bg-teal-500 hover:bg-teal-700 border-teal-500 hover:border-teal-700 text-white text-sm border-4 py-1 px-2 rounded">
-        作成日順
-      </button>
-      <button type="submit" name="sort" value="1" class="flex-shrink-0 bg-teal-500 hover:bg-teal-700 border-teal-500 hover:border-teal-700 text-white text-sm border-4 py-1 px-2 rounded">
-        期限が近い順
-      </button>
+      @csrf
+        <button type="submit" name="sort" value="0" class="flex-shrink-0 bg-teal-500 hover:bg-teal-700 border-teal-500 hover:border-teal-700 text-white text-sm border-4 py-1 px-2 rounded">
+          作成日順
+        </button>
+        <button type="submit" name="sort" value="1" class="flex-shrink-0 bg-teal-500 hover:bg-teal-700 border-teal-500 hover:border-teal-700 text-white text-sm border-4 py-1 px-2 rounded">
+          期限が近い順
+        </button>
     </form>
   </div>
 

--- a/resources/views/task/done.blade.php
+++ b/resources/views/task/done.blade.php
@@ -18,8 +18,13 @@
               <div class="text-sm text-gray-900 pr-3">タグの登録数：0</div>
             @endforelse
           </div>
-          <div class="flex items-center">
+          <div class="flex items-center pr-3">
             <input type="submit" value="タグで検索" class="flex-shrink-0 bg-teal-500 hover:bg-teal-700 border-teal-500 hover:border-teal-700 text-sm border-4 text-white py-1 px-2 rounded">
+          </div>
+          <div class="flex items-center">
+            <button class="flex-shrink-0 bg-indigo-900 hover:bg-indigo-700 border-indigo-900 hover:border-indigo-700 text-white text-sm border-4 py-1 px-2 rounded">
+              <a href="{{ route('tag.index') }}">タグの管理</a>
+            </button>
           </div>
         @endif
       </div>

--- a/resources/views/task/index.blade.php
+++ b/resources/views/task/index.blade.php
@@ -18,8 +18,13 @@
                 <div class="text-sm text-gray-900 pr-3">タグの登録数：0</div>
               @endforelse
             </div>
-            <div class="flex items-center">
+            <div class="flex items-center pr-3">
               <input type="submit" value="タグで検索" class="flex-shrink-0 bg-teal-500 hover:bg-teal-700 border-teal-500 hover:border-teal-700 text-sm border-4 text-white py-1 px-2 rounded">
+            </div>
+            <div class="flex items-center">
+              <button class="flex-shrink-0 bg-indigo-900 hover:bg-indigo-700 border-indigo-900 hover:border-indigo-700 text-white text-sm border-4 py-1 px-2 rounded">
+                <a href="{{ route('tag.index') }}">タグの管理</a>
+              </button>
             </div>
           @endif
         </div>

--- a/resources/views/task/index.blade.php
+++ b/resources/views/task/index.blade.php
@@ -1,41 +1,43 @@
 <x-app-layout>
   <div class="flex justify-center text-xl pt-6">
     <form action="{{ route('task_index') }}" method="GET" class="px-64">
-      <div class="flex items-center border-b border-teal-700">
-        <input type="text" name="keyword" value="{{ $keyword }}" class="appearance-none bg-transparent border-none w-full text-gray-700 mr-3 py-1 px-2 leading-tight focus:outline-none">
-        <input type="submit" value="検索" class="flex-shrink-0 bg-teal-500 hover:bg-teal-700 border-teal-500 hover:border-teal-700 text-white text-sm border-4 py-1 px-2 rounded">
-      </div>
-      <div class="flex justify-center pt-6">
-        @if ($tags)
-          <div class="flex flex-wrap items-center">
-            @forelse ($tags as $tag)
-              <label>
-                <input type="radio" name="select_tag" value="{{ $tag->name }}">
-                <span class="text-sm pr-6 text-gray-900">{{ $tag->name }}</span>
-              </label>
-            @empty
-              <div class="text-sm text-gray-900 pr-3">タグの登録数：0</div>
-            @endforelse
-          </div>
-          <div class="flex items-center">
-            <input type="submit" value="タグで検索" class="flex-shrink-0 bg-teal-500 hover:bg-teal-700 border-teal-500 hover:border-teal-700 text-sm border-4 text-white py-1 px-2 rounded">
-          </div>
-        @endif
-      </div>
+      @csrf
+        <div class="flex items-center border-b border-teal-700">
+          <input type="text" name="keyword" value="{{ $keyword }}" class="appearance-none bg-transparent border-none w-full text-gray-700 mr-3 py-1 px-2 leading-tight focus:outline-none">
+          <input type="submit" value="検索" class="flex-shrink-0 bg-teal-500 hover:bg-teal-700 border-teal-500 hover:border-teal-700 text-white text-sm border-4 py-1 px-2 rounded">
+        </div>
+        <div class="flex justify-center pt-6">
+          @if ($tags)
+            <div class="flex flex-wrap items-center">
+              @forelse ($tags as $tag)
+                <label>
+                  <input type="radio" name="select_tag" value="{{ $tag->name }}">
+                  <span class="text-sm pr-6 text-gray-900">{{ $tag->name }}</span>
+                </label>
+              @empty
+                <div class="text-sm text-gray-900 pr-3">タグの登録数：0</div>
+              @endforelse
+            </div>
+            <div class="flex items-center">
+              <input type="submit" value="タグで検索" class="flex-shrink-0 bg-teal-500 hover:bg-teal-700 border-teal-500 hover:border-teal-700 text-sm border-4 text-white py-1 px-2 rounded">
+            </div>
+          @endif
+        </div>
     </form>
   </div>
 
   <div class="flex justify-center text-xl pt-6">
     <form action="{{route('task_index')}}">
-      <button type="submit" name="sort" value="0" class="flex-shrink-0 bg-teal-500 hover:bg-teal-700 border-teal-500 hover:border-teal-700 text-white text-sm border-4 py-1 px-2 rounded">
-        作成日順
-      </button>
-      <button type="submit" name="sort" value="1" class="flex-shrink-0 bg-teal-500 hover:bg-teal-700 border-teal-500 hover:border-teal-700 text-white text-sm border-4 py-1 px-2 rounded">
-        期限が近い順
-      </button>
-      <button type="submit" name="sort" value="2" class="flex-shrink-0 bg-teal-500 hover:bg-teal-700 border-teal-500 hover:border-teal-700 text-white text-sm border-4 py-1 px-2 rounded">
-        ステータス順
-      </button>
+      @csrf
+        <button type="submit" name="sort" value="0" class="flex-shrink-0 bg-teal-500 hover:bg-teal-700 border-teal-500 hover:border-teal-700 text-white text-sm border-4 py-1 px-2 rounded">
+          作成日順
+        </button>
+        <button type="submit" name="sort" value="1" class="flex-shrink-0 bg-teal-500 hover:bg-teal-700 border-teal-500 hover:border-teal-700 text-white text-sm border-4 py-1 px-2 rounded">
+          期限が近い順
+        </button>
+        <button type="submit" name="sort" value="2" class="flex-shrink-0 bg-teal-500 hover:bg-teal-700 border-teal-500 hover:border-teal-700 text-white text-sm border-4 py-1 px-2 rounded">
+          ステータス順
+        </button>
     </form>
   </div>
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -2,6 +2,7 @@
 
 use App\Http\Controllers\ProfileController;
 use App\Http\Controllers\TaskController;
+use App\Http\Controllers\TagController;
 use App\Http\Middleware\TaskMiddleware;
 use Illuminate\Foundation\Application;
 use Illuminate\Support\Facades\Route;
@@ -40,6 +41,7 @@ Route::middleware('auth')->group(function () {
     Route::get('task/find', [TaskController::class, 'find'])->name('task_find');
     Route::post('task/find', [TaskController::class, 'search']);
     Route::get('task/done', [TaskController::class, 'done'])->name('done_task');
+    Route::resource('tag', TagController::class)->only(['index', 'update', 'destroy', 'edit']);
 });
 
 require __DIR__.'/auth.php';


### PR DESCRIPTION
## 概要

タグを管理するページを作成しました。

## 確認方法

1. 未着手・完了タスクの各一覧ページからタスク管理ページへ遷移できること。
2. タスク管理ページではログインユーザーが登録しているタグ一覧が表示されること。
3. タスク管理ページから直接タグの更新・削除を行えること。

## コメント

タグの更新時のバリデーションで上手く設定できなかった箇所については次回修正します。
#58 
